### PR TITLE
修改了show.py选取文件名的默认值

### DIFF
--- a/show.py
+++ b/show.py
@@ -130,7 +130,7 @@ def main():
             # 没找到，说明本目录下没有这个测试文件
             raise NameError("No Test File in this directory.")
                 
-        logname = '[W.T]T_idiot-VS-T_idiot'
+        # logname = '[W.T]T_idiot-VS-T_idiot'
     
     #读出log
     log = readlog(logname)

--- a/show.py
+++ b/show.py
@@ -116,21 +116,20 @@ def main():
         logname = sys.argv[1]
     else:
         # 这里对当前目录进行搜索，找到一个字节数不为0的dat文件
-        import os,re
-        file_list = os.listdir()
+        import os, re
+        file_list = os.listdir(os.getcwd())
         # 编译正则表达式，寻找对应的文件名
-        r = re.compile(r'^\[(W|E)\.[A-Z]\]T_[^-]+-VS-T_[^.]+\.dat$')
-        # 首先保证是文件而不是目录
-        for name in filter(lambda f: os.path.isfile(f), file_list):
+        r = re.compile(r'^\[[EW]\.[A-Z]\]T_[^-]+-VS-T_[^.]+\.dat$')
+        # 首先保证是文件而不是目录，且不为空
+        for name in filter(lambda f: os.path.isfile(f) and os.path.getsize(f) != 0, file_list):
             m = r.match(name)
             if m is not None:
                 # 不为空，则拿到了一个正确的文件
-                logname = name[:-4] # 去除.dat后缀
+                logname = name[:-4]  # 去除.dat后缀
+                break
         else:
             # 没找到，说明本目录下没有这个测试文件
             raise NameError("No Test File in this directory.")
-                
-        # logname = '[W.T]T_idiot-VS-T_idiot'
     
     #读出log
     log = readlog(logname)

--- a/show.py
+++ b/show.py
@@ -115,6 +115,21 @@ def main():
     if len(sys.argv)==2:
         logname = sys.argv[1]
     else:
+        # 这里对当前目录进行搜索，找到一个字节数不为0的dat文件
+        import os,re
+        file_list = os.listdir()
+        # 编译正则表达式，寻找对应的文件名
+        r = re.compile(r'^\[(W|E)\.[A-Z]\]T_[^-]+-VS-T_[^.]+\.dat$')
+        # 首先保证是文件而不是目录
+        for name in filter(lambda f: os.path.isfile(f), file_list):
+            m = r.match(name)
+            if m is not None:
+                # 不为空，则拿到了一个正确的文件
+                logname = name[:-4] # 去除.dat后缀
+        else:
+            # 没找到，说明本目录下没有这个测试文件
+            raise NameError("No Test File in this directory.")
+                
         logname = '[W.T]T_idiot-VS-T_idiot'
     
     #读出log


### PR DESCRIPTION
从一个恒定值（常常是不存在的）改成了使用正则表达式遍历同一目录下的所有文件的名称，满足要求的才被导入。极大降低了调试出错的可能。（虽然对正式比赛没有影响） #19 